### PR TITLE
Suppress DeprecationWarnings in tests using pytest.mark.filterwarnings

### DIFF
--- a/tests/test_api/test_client/test_session/test_base_session.py
+++ b/tests/test_api/test_client/test_session/test_base_session.py
@@ -54,6 +54,7 @@ class CustomSession(BaseSession):
         yield b"\f" * 10
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestBaseSession:
     def test_init_api(self):
         session = CustomSession()


### PR DESCRIPTION
Added suppression for `DeprecationWarning` across all test cases using `@pytest.mark.filterwarnings("ignore::DeprecationWarning")` decorator. This change ensures that deprecation warnings do not clutter test output, focusing on actual test results and errors.

### Changes:
- Applied `@pytest.mark.filterwarnings("ignore::DeprecationWarning")` decorator to the `TestBaseSession` class.
- This approach globally suppresses deprecation warnings during the execution of tests in the class, avoiding the need to handle warnings in individual test methods.