### PR TITLE
Deprecate `json_loads`, `json_dumps`, and `timeout` in BaseSession. Suppress DeprecationWarnings in tests using pytest.mark.filterwarnings

### DIFF
--- a/aiogram/client/session/base.py
+++ b/aiogram/client/session/base.py
@@ -50,30 +50,38 @@ DEFAULT_TIMEOUT: Final[float] = 60.0
 class BaseSession(abc.ABC):
     """
     This is base class for all HTTP sessions in aiogram.
-
-    If you want to create your own session, you must inherit from this class.
+    
+    The parameters `json_loads`, `json_dumps`, and `timeout` are deprecated
+    and will be removed in version 3.14.0. These parameters are no longer used,
+    and the corresponding functionalities have been replaced by pydantic's 
+    built-in serialization/deserialization methods.
     """
 
+
     def __init__(
-        self,
-        api: TelegramAPIServer = PRODUCTION,
-        json_loads: _JsonLoads = json.loads,
-        json_dumps: _JsonDumps = json.dumps,
-        timeout: float = DEFAULT_TIMEOUT,
-    ) -> None:
-        """
+    self,
+    api: TelegramAPIServer = PRODUCTION,
+    json_loads: Optional[_JsonLoads] = None,
+    json_dumps: Optional[_JsonDumps] = None,
+    timeout: Optional[float] = None,
+) -> None:
+    """
+    :param api: Telegram Bot API URL patterns
+    :param json_loads: JSON loader (deprecated, not used)
+    :param json_dumps: JSON dumper (deprecated, not used)
+    :param timeout: Session scope request timeout (deprecated, not used)
+    """
+    if json_loads is not None or json_dumps is not None or timeout is not None:
+        warnings.warn(
+            "Parameters `json_loads`, `json_dumps`, and `timeout` are deprecated "
+            "and will be removed in aiogram 3.14.0. These parameters are no longer used.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
-        :param api: Telegram Bot API URL patterns
-        :param json_loads: JSON loader
-        :param json_dumps: JSON dumper
-        :param timeout: Session scope request timeout
-        """
-        self.api = api
-        self.json_loads = json_loads
-        self.json_dumps = json_dumps
-        self.timeout = timeout
-
-        self.middleware = RequestMiddlewareManager()
+    self.api = api
+    self.middleware = RequestMiddlewareManager()
+    
 
     def check_response(
         self, bot: Bot, method: TelegramMethod[TelegramType], status_code: int, content: str

--- a/tests/test_api/test_client/test_session/test_base_session.py
+++ b/tests/test_api/test_client/test_session/test_base_session.py
@@ -54,6 +54,7 @@ class CustomSession(BaseSession):
         yield b"\f" * 10
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestBaseSession:
     def test_init_api(self):
         session = CustomSession()


### PR DESCRIPTION
The parameters `json_loads`, `json_dumps`, and `timeout` in the `BaseSession` class have been marked as deprecated and are scheduled for removal in version 3.14.0.

### Changes:
- Removed internal usage of `json_loads`, `json_dumps`, and `timeout`.
- Added a `DeprecationWarning` when these parameters are passed to the constructor.
- Updated class and method docstrings to reflect the deprecation and explain that these parameters are no longer used.
- The corresponding functionalities are now handled by pydantic's built-in serialization/deserialization methods.
Added suppression for `DeprecationWarning` across all test cases using `@pytest.mark.filterwarnings("ignore::DeprecationWarning")` decorator. This change ensures that deprecation warnings do not clutter test output, focusing on actual test results and errors.
- Applied `@pytest.mark.filterwarnings("ignore::DeprecationWarning")` decorator to the `TestBaseSession` class.
- This approach globally suppresses deprecation warnings during the execution of tests in the class, avoiding the need to handle warnings in individual test methods.